### PR TITLE
Nightly fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "core_simd"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/stdsimd#d42875302dd9e924f8d667b32e88989388989b79"
+source = "git+https://github.com/rust-lang/stdsimd#a16b481a08a3d7560f9c92370f18f6ee8c006c9e"
 
 [[package]]
 name = "g3"
@@ -44,18 +44,18 @@ checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Rust crate for plane-based projective geometric-algebra for 3D aka the Clifford 
 This software uses some of Rust experimental feautures like `std_simd` and `fn_traits` so make sure to compile using the nightly release.
 
 ```bash
-rustup default nightly-2021-08-28˝
+rustup update -- nightly
 ```
 
 ## Awesome Links


### PR DESCRIPTION
Found out that `core_simd` does work on latest nightly. Problem was that the Cargo.lock file pins it to an older commit, which I guess `cargo clean` didn't fix (or I forgot to run)

Another idea could be gitignoring Cargo.lock, at least until it can be put on crates.io